### PR TITLE
chore(gitignore): add vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .DS_Store
 .idea/
 .swp
+vendor/


### PR DESCRIPTION
Fixes #296 https://github.com/EVERSE-ResearchSoftware/RSQKit/issues/296

Changes proposed in this pull request:

* adds `vendor/` to `.gitignore`

Notes for reviewers: 

* When following INSTALL.md, and running bundle install, it installs all the dependencies under vendor and git still tracks all the packages. Only adding vendor to .gitignore.
